### PR TITLE
Handle 404 with custom middleware

### DIFF
--- a/Middleware/NotFoundMiddleware.cs
+++ b/Middleware/NotFoundMiddleware.cs
@@ -1,0 +1,37 @@
+using System.Net;
+using System.Text.Json;
+using BookStore.Models.ResponeApi;
+
+namespace BookStore.Middleware
+{
+    public class NotFoundMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public NotFoundMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            await _next(context);
+
+            if (context.Response.StatusCode == (int)HttpStatusCode.NotFound && !context.Response.HasStarted)
+            {
+                var res = new ApiResponse<string>(
+                    Code: context.Response.StatusCode,
+                    Data: null,
+                    Message: "Resource not found",
+                    Success: false
+                );
+
+                var option = new JsonSerializerOptions { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
+                var json = JsonSerializer.Serialize(res, option);
+
+                context.Response.ContentType = "application/json";
+                await context.Response.WriteAsync(json);
+            }
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -165,5 +165,6 @@ app.UseAuthentication();
 app.UseAuthorization();
 
 app.UseHttpsRedirection();
+app.UseMiddleware<NotFoundMiddleware>();
 app.MapControllers();
 app.Run();


### PR DESCRIPTION
## Summary
- add `NotFoundMiddleware` to send JSON response when a resource is not found
- register new middleware in `Program.cs`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847066384c8832ab539492301b7b3d2